### PR TITLE
Implement start date change handling in EventEdit component

### DIFF
--- a/LotusPlanningApp/LotusPlanningApp/Components/Pages/EventEdit.razor
+++ b/LotusPlanningApp/LotusPlanningApp/Components/Pages/EventEdit.razor
@@ -110,7 +110,7 @@ else
                             <div class="row">
                                 <div class="col-md-6 mb-3">
                                     <label class="form-label">Startdatum & tijd *</label>
-                                    <input type="datetime-local" @bind="editForm.StartDate" class="form-control" />
+                                    <input type="datetime-local" value="@editForm.StartDate.ToString("yyyy-MM-ddTHH:mm")" @onchange="OnStartDateChanged" class="form-control" />
                                     <ValidationMessage For="() => editForm.StartDate" class="text-danger" />
                                 </div>
                                 <div class="col-md-6 mb-3">
@@ -587,5 +587,22 @@ else
             ShiftStatus.Cancelled => "danger",
             _ => "secondary"
         };
+    }
+
+    private void OnStartDateChanged(ChangeEventArgs e)
+    {
+        if (e.Value != null && DateTime.TryParse(e.Value.ToString(), out var newStartDate))
+        {
+            // Store the original end date time part
+            var endDateTime = editForm.EndDate.TimeOfDay;
+            
+            // Update the start date
+            editForm.StartDate = newStartDate;
+            
+            // Update the end date: use the new start date's date part with the original end date's time part
+            editForm.EndDate = newStartDate.Date + endDateTime;
+            
+            StateHasChanged();
+        }
     }
 }


### PR DESCRIPTION
- Updated the start date input to use a value binding with an onchange event.
- Added OnStartDateChanged method to update the start date and adjust the end date accordingly, preserving the original time part of the end date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit change handling for the start datetime field to keep dates consistent.
> 
> - Switches `input[type="datetime-local"]` for `StartDate` from `@bind` to `value` + `@onchange` with formatted `yyyy-MM-ddTHH:mm`
> - Introduces `OnStartDateChanged` to set `editForm.StartDate` and update `editForm.EndDate` to the new date while preserving the original end time
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7b2300dc99a49aeb7d5eaed280d4f39844cb2e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->